### PR TITLE
Add targeted test coverage.

### DIFF
--- a/apps/web/src/atoms/storage-atoms.test.tsx
+++ b/apps/web/src/atoms/storage-atoms.test.tsx
@@ -1,0 +1,125 @@
+import { act, renderHook } from "@testing-library/react";
+import { Provider } from "jotai";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  useLanguage,
+  useLanguageValue,
+  useSetLanguage,
+} from "@/atoms/language";
+import { usePeriod, usePeriodValue, useSetPeriod } from "@/atoms/period";
+import {
+  usePersonalAccessToken,
+  usePersonalAccessTokenValue,
+  useSetPersonalAccessToken,
+} from "@/atoms/personal-access-token";
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <Provider>{children}</Provider>;
+}
+
+describe("storage atoms", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("reads and updates language through all language hooks", () => {
+    localStorage.setItem("language", JSON.stringify("TypeScript"));
+
+    const { result } = renderHook(
+      () => {
+        const [language, setLanguage] = useLanguage();
+        const languageValue = useLanguageValue();
+        const setLanguageOnly = useSetLanguage();
+
+        return {
+          language,
+          setLanguage,
+          languageValue,
+          setLanguageOnly,
+        };
+      },
+      { wrapper: Wrapper },
+    );
+
+    expect(result.current.language).toBe("TypeScript");
+    expect(result.current.languageValue).toBe("TypeScript");
+
+    act(() => {
+      result.current.setLanguage("Rust");
+    });
+    expect(result.current.languageValue).toBe("Rust");
+
+    act(() => {
+      result.current.setLanguageOnly("Go");
+    });
+    expect(result.current.language).toBe("Go");
+  });
+
+  it("reads and updates period through all period hooks", () => {
+    localStorage.setItem("period", JSON.stringify("weekly"));
+
+    const { result } = renderHook(
+      () => {
+        const [period, setPeriod] = usePeriod();
+        const periodValue = usePeriodValue();
+        const setPeriodOnly = useSetPeriod();
+
+        return {
+          period,
+          setPeriod,
+          periodValue,
+          setPeriodOnly,
+        };
+      },
+      { wrapper: Wrapper },
+    );
+
+    expect(result.current.period).toBe("weekly");
+    expect(result.current.periodValue).toBe("weekly");
+
+    act(() => {
+      result.current.setPeriod("monthly");
+    });
+    expect(result.current.periodValue).toBe("monthly");
+
+    act(() => {
+      result.current.setPeriodOnly("yearly");
+    });
+    expect(result.current.period).toBe("yearly");
+  });
+
+  it("reads and updates personal access token through all token hooks", () => {
+    localStorage.setItem("personalAccessToken", JSON.stringify("abc123"));
+
+    const { result } = renderHook(
+      () => {
+        const [personalAccessToken, setPersonalAccessToken] =
+          usePersonalAccessToken();
+        const personalAccessTokenValue = usePersonalAccessTokenValue();
+        const setPersonalAccessTokenOnly = useSetPersonalAccessToken();
+
+        return {
+          personalAccessToken,
+          setPersonalAccessToken,
+          personalAccessTokenValue,
+          setPersonalAccessTokenOnly,
+        };
+      },
+      { wrapper: Wrapper },
+    );
+
+    expect(result.current.personalAccessToken).toBe("abc123");
+    expect(result.current.personalAccessTokenValue).toBe("abc123");
+
+    act(() => {
+      result.current.setPersonalAccessToken("new-token");
+    });
+    expect(result.current.personalAccessTokenValue).toBe("new-token");
+
+    act(() => {
+      result.current.setPersonalAccessTokenOnly(null);
+    });
+    expect(result.current.personalAccessToken).toBeNull();
+  });
+});

--- a/apps/web/src/components/app-shell.test.tsx
+++ b/apps/web/src/components/app-shell.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import type { ComponentProps, ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { AppShell } from "./app-shell";
+
+vi.mock("@/components/language-select", () => ({
+  LanguageSelect: () => <div>Language Select</div>,
+}));
+
+vi.mock("@/components/logo", () => ({
+  Logo: () => <div>Logo</div>,
+}));
+
+vi.mock("@/components/period-select", () => ({
+  PeriodSelect: () => <div>Period Select</div>,
+}));
+
+vi.mock("@/components/settings-dropdown", () => ({
+  SettingsDropdown: () => <div>Settings Dropdown</div>,
+}));
+
+vi.mock("@/components/ui/app-bar", () => ({
+  AppBar: ({
+    children,
+    ...props
+  }: ComponentProps<"div"> & { children: ReactNode }) => (
+    <div data-testid="app-bar" {...props}>
+      {children}
+    </div>
+  ),
+}));
+
+describe("AppShell", () => {
+  it("renders shared layout chrome and children content", () => {
+    render(
+      <AppShell data-testid="app-shell">
+        <p>Repository content</p>
+      </AppShell>,
+    );
+
+    expect(screen.getByTestId("app-shell")).toBeInTheDocument();
+    expect(screen.getByTestId("app-bar")).toBeInTheDocument();
+    expect(screen.getByText("Trending Repositories")).toBeInTheDocument();
+    expect(screen.getByText("Logo")).toBeInTheDocument();
+    expect(screen.getByText("Language Select")).toBeInTheDocument();
+    expect(screen.getByText("Period Select")).toBeInTheDocument();
+    expect(screen.getByText("Settings Dropdown")).toBeInTheDocument();
+    expect(screen.getByText("Repository content")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/language-indicator.test.tsx
+++ b/apps/web/src/components/language-indicator.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { languages } from "@/lib/languages";
+import { LanguageIndicator } from "./language-indicator";
+
+describe("LanguageIndicator", () => {
+  it("uses the configured language color", () => {
+    render(<LanguageIndicator data-testid="indicator" language="TypeScript" />);
+
+    expect(screen.getByTestId("indicator")).toHaveStyle({
+      backgroundColor: languages.colors.TypeScript,
+    });
+  });
+
+  it("uses the special all languages color", () => {
+    render(
+      <LanguageIndicator data-testid="indicator" language="All Languages" />,
+    );
+
+    expect(screen.getByTestId("indicator")).toHaveStyle({
+      backgroundColor: "#ef4444",
+    });
+  });
+});

--- a/apps/web/src/components/loader.test.tsx
+++ b/apps/web/src/components/loader.test.tsx
@@ -1,0 +1,18 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import Loader from "./loader";
+
+vi.mock("@/components/repository-skeleton", () => ({
+  RepositorySkeleton: () => <div data-testid="repository-skeleton" />,
+}));
+
+describe("Loader", () => {
+  it("renders 20 repository skeleton items", () => {
+    const { container, getAllByTestId } = render(<Loader />);
+
+    expect(container.querySelectorAll('[data-slot="item-group"]')).toHaveLength(
+      1,
+    );
+    expect(getAllByTestId("repository-skeleton")).toHaveLength(20);
+  });
+});

--- a/apps/web/src/components/logo.test.tsx
+++ b/apps/web/src/components/logo.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { Logo } from "./logo";
+
+vi.mock("@unpic/react", () => ({
+  Image: (props: ComponentProps<"img">) => <img alt="" {...props} />,
+}));
+
+describe("Logo", () => {
+  it("renders a secure external link with logo image", () => {
+    render(<Logo className="custom-logo" />);
+
+    const link = screen.getByRole("link", { name: "Twending" });
+    const image = screen.getByAltText("Twending");
+
+    expect(link).toHaveAttribute(
+      "href",
+      "https://github.com/brettm12345/twending",
+    );
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    expect(link).toHaveClass("custom-logo");
+    expect(image).toHaveAttribute("src", "/logo.png");
+    expect(image).toHaveClass("custom-logo");
+  });
+});

--- a/apps/web/src/components/repository-skeleton.test.tsx
+++ b/apps/web/src/components/repository-skeleton.test.tsx
@@ -1,0 +1,22 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { RepositorySkeleton } from "./repository-skeleton";
+
+vi.mock("@/components/ui/skeleton", () => ({
+  Skeleton: ({ className }: { className?: string }) => (
+    <span className={className} data-slot="skeleton" />
+  ),
+}));
+
+describe("RepositorySkeleton", () => {
+  it("renders expected skeleton placeholders", () => {
+    const { container, getByTestId } = render(
+      <RepositorySkeleton data-testid="repository-skeleton-item" />,
+    );
+
+    expect(getByTestId("repository-skeleton-item")).toBeInTheDocument();
+    expect(container.querySelectorAll('[data-slot="skeleton"]')).toHaveLength(
+      8,
+    );
+  });
+});

--- a/apps/web/src/hooks/use-intersection-observer.test.tsx
+++ b/apps/web/src/hooks/use-intersection-observer.test.tsx
@@ -1,0 +1,104 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useIntersectionObserver } from "./use-intersection-observer";
+
+const createEntry = (
+  target: Element,
+  overrides: Partial<IntersectionObserverEntry> = {},
+): IntersectionObserverEntry =>
+  ({
+    boundingClientRect: {} as DOMRectReadOnly,
+    intersectionRatio: 0,
+    intersectionRect: {} as DOMRectReadOnly,
+    isIntersecting: false,
+    rootBounds: null,
+    target,
+    time: Date.now(),
+    ...overrides,
+  }) as IntersectionObserverEntry;
+
+describe("useIntersectionObserver", () => {
+  it("observes the current element, forwards entries, and cleans up on unmount", () => {
+    const observe = vi.fn();
+    const unobserve = vi.fn();
+    let callback: IntersectionObserverCallback | undefined;
+
+    class MockIntersectionObserver implements IntersectionObserver {
+      readonly root = null;
+      readonly rootMargin = "";
+      readonly thresholds = [];
+
+      constructor(observerCallback: IntersectionObserverCallback) {
+        callback = observerCallback;
+      }
+
+      disconnect = vi.fn();
+      observe = observe;
+      takeRecords = vi.fn(() => []);
+      unobserve = unobserve;
+    }
+
+    vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+
+    const element = document.createElement("div");
+    const ref = { current: element };
+    const onIntersection = vi.fn();
+
+    const { result, unmount } = renderHook(() =>
+      useIntersectionObserver(ref, { threshold: 0.5 }, onIntersection),
+    );
+
+    expect(result.current).toBe(ref);
+    expect(observe).toHaveBeenCalledWith(element);
+
+    act(() => {
+      callback?.(
+        [createEntry(element, { isIntersecting: true, intersectionRatio: 1 })],
+        {} as IntersectionObserver,
+      );
+    });
+
+    expect(onIntersection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: element,
+        isIntersecting: true,
+        intersectionRatio: 1,
+      }),
+    );
+
+    unmount();
+
+    expect(unobserve).toHaveBeenCalledWith(element);
+  });
+
+  it("skips observation when the ref has no current element", () => {
+    const observe = vi.fn();
+    const unobserve = vi.fn();
+
+    class MockIntersectionObserver implements IntersectionObserver {
+      readonly root = null;
+      readonly rootMargin = "";
+      readonly thresholds = [];
+
+      disconnect = vi.fn();
+      observe = observe;
+      takeRecords = vi.fn(() => []);
+      unobserve = unobserve;
+    }
+
+    vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+
+    const ref = { current: null as HTMLDivElement | null };
+    const onIntersection = vi.fn();
+
+    const { unmount } = renderHook(() =>
+      useIntersectionObserver(ref, {}, onIntersection),
+    );
+
+    expect(observe).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(unobserve).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/utils/seo.test.ts
+++ b/apps/web/src/utils/seo.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { seo } from "./seo";
 
 describe("seo", () => {
-  it("returns the base metadata when no image is provided", () => {
+  it("returns the base metadata when image is an empty string", () => {
     const metadata = seo({
       title: "Twending",
       description: "Trending repositories by language",

--- a/apps/web/src/utils/seo.test.ts
+++ b/apps/web/src/utils/seo.test.ts
@@ -25,11 +25,11 @@ describe("seo", () => {
         },
       ]),
     );
-    expect(metadata).not.toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ property: "og:image" }),
-        expect.objectContaining({ name: "twitter:image" }),
-      ]),
+    expect(metadata).not.toContainEqual(
+      expect.objectContaining({ property: "og:image" }),
+    );
+    expect(metadata).not.toContainEqual(
+      expect.objectContaining({ name: "twitter:image" }),
     );
   });
 

--- a/apps/web/src/utils/seo.test.ts
+++ b/apps/web/src/utils/seo.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { seo } from "./seo";
+
+describe("seo", () => {
+  it("returns the base metadata when no image is provided", () => {
+    const metadata = seo({
+      title: "Twending",
+      description: "Trending repositories by language",
+      image: "",
+      keywords: ["github", "trending", "typescript"],
+    });
+
+    expect(metadata).toEqual(
+      expect.arrayContaining([
+        { title: "Twending" },
+        { charSet: "utf-8" },
+        {
+          name: "viewport",
+          content: "width=device-width, initial-scale=1.0",
+        },
+        { property: "keywords", content: "github,trending,typescript" },
+        {
+          property: "description",
+          content: "Trending repositories by language",
+        },
+      ]),
+    );
+    expect(metadata).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ property: "og:image" }),
+        expect.objectContaining({ name: "twitter:image" }),
+      ]),
+    );
+  });
+
+  it("includes open graph and twitter image metadata when an image is provided", () => {
+    const image = "https://example.com/og.png";
+
+    const metadata = seo({
+      title: "Twending",
+      description: "Trending repositories by language",
+      image,
+      keywords: ["github"],
+    });
+
+    expect(metadata).toEqual(
+      expect.arrayContaining([
+        { property: "og:image", content: image },
+        { property: "og:image:width", content: "1200" },
+        { property: "og:image:height", content: "630" },
+        { name: "twitter:image", content: image },
+        { name: "twitter:card", content: "summary_large_image" },
+      ]),
+    );
+  });
+});

--- a/packages/api/src/routers/index.test.ts
+++ b/packages/api/src/routers/index.test.ts
@@ -131,4 +131,32 @@ describe("appRouter", () => {
     });
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it("defaults cursor to zero when omitted", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-18T12:00:00.000Z"));
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      json: async () => ({
+        total_count: 1,
+        incomplete_results: false,
+        items: [repository],
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const caller = appRouter.createCaller({});
+    const result = await caller.listRepositories({
+      language: "TypeScript",
+      period: "daily",
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const url = fetchMock.mock.calls[0]?.[0];
+    const called = new URL(url);
+    expect(called.searchParams.get("q")).toBe(
+      "language:TypeScript created:2026-04-17T12:00:00.000Z..2026-04-18T12:00:00.000Z",
+    );
+    expect(result.nextCursor).toBe(1);
+  });
 });

--- a/packages/api/src/routers/index.test.ts
+++ b/packages/api/src/routers/index.test.ts
@@ -112,7 +112,18 @@ describe("appRouter", () => {
     expect(called.searchParams.get("q")).toBe(
       `language:TypeScript created:${expectedRange}`,
     );
-    expect(options).toEqual({ headers: undefined });
+    const headers = options?.headers;
+
+    if (headers instanceof Headers) {
+      expect(headers.has("Authorization")).toBe(false);
+    } else if (Array.isArray(headers)) {
+      expect(
+        headers.some(([name]) => name.toLowerCase() === "authorization"),
+      ).toBe(false);
+    } else {
+      expect(headers?.Authorization).toBeUndefined();
+      expect(headers?.authorization).toBeUndefined();
+    }
   });
 
   it("rejects invalid period input before calling GitHub", async () => {

--- a/packages/api/src/routers/index.test.ts
+++ b/packages/api/src/routers/index.test.ts
@@ -69,6 +69,52 @@ describe("appRouter", () => {
     });
   });
 
+  it.each([
+    {
+      period: "daily",
+      expectedRange: "2026-04-16T12:00:00.000Z..2026-04-17T12:00:00.000Z",
+    },
+    {
+      period: "monthly",
+      expectedRange: "2026-02-17T12:00:00.000Z..2026-03-19T12:00:00.000Z",
+    },
+    {
+      period: "yearly",
+      expectedRange: "2024-04-18T12:00:00.000Z..2025-04-18T12:00:00.000Z",
+    },
+  ] as const)("builds the correct $period range without an authorization header", async ({
+    period,
+    expectedRange,
+  }) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-18T12:00:00.000Z"));
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      json: async () => ({
+        total_count: 1,
+        incomplete_results: false,
+        items: [repository],
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const caller = appRouter.createCaller({});
+    await caller.listRepositories({
+      language: "TypeScript",
+      period,
+      cursor: 1,
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, options] = fetchMock.mock.calls[0] ?? [];
+    const called = new URL(url);
+
+    expect(called.searchParams.get("q")).toBe(
+      `language:TypeScript created:${expectedRange}`,
+    );
+    expect(options).toEqual({ headers: undefined });
+  });
+
   it("rejects invalid period input before calling GitHub", async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);


### PR DESCRIPTION
Cover key helper and router branches so the existing coverage reports catch more regressions.

Made-with: Cursor