### PR TITLE
Add nuqs integration to LanguageSelect and PeriodSelect components

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,6 +24,7 @@
     "jotai": "^2.19.1",
     "motion": "^12.38.0",
     "nitro": "3.0.1-alpha.2",
+    "nuqs": "^2.8.9",
     "posthog-js": "^1.369.3",
     "react": "19.2.5",
     "react-dom": "19.2.5",

--- a/apps/web/src/components/language-select.test.tsx
+++ b/apps/web/src/components/language-select.test.tsx
@@ -1,9 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { Provider } from "jotai";
-import {
-  type UrlUpdateEvent,
-  withNuqsTestingAdapter,
-} from "nuqs/adapters/testing";
+import { withNuqsTestingAdapter } from "nuqs/adapters/testing";
 import type { ComponentProps, ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { LanguageSelect } from "./language-select";

--- a/apps/web/src/components/language-select.test.tsx
+++ b/apps/web/src/components/language-select.test.tsx
@@ -1,5 +1,9 @@
 import { render, screen } from "@testing-library/react";
 import { Provider } from "jotai";
+import {
+  type UrlUpdateEvent,
+  withNuqsTestingAdapter,
+} from "nuqs/adapters/testing";
 import type { ComponentProps, ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { LanguageSelect } from "./language-select";
@@ -108,7 +112,7 @@ describe("LanguageSelect", () => {
     localStorage.setItem("language", JSON.stringify("TypeScript"));
 
     render(<LanguageSelect data-testid="language-select" />, {
-      wrapper: Wrapper,
+      wrapper: withNuqsTestingAdapter(),
     });
 
     // Current language appears in the button trigger
@@ -120,7 +124,7 @@ describe("LanguageSelect", () => {
   it("renders the All Languages option", () => {
     localStorage.setItem("language", JSON.stringify("All Languages"));
 
-    render(<LanguageSelect />, { wrapper: Wrapper });
+    render(<LanguageSelect />, { wrapper: withNuqsTestingAdapter() });
 
     const allLanguagesElements = screen.getAllByText("All Languages");
     expect(allLanguagesElements.length).toBeGreaterThanOrEqual(1);
@@ -129,7 +133,7 @@ describe("LanguageSelect", () => {
   it("renders popular and other language groups", () => {
     localStorage.setItem("language", JSON.stringify("All Languages"));
 
-    render(<LanguageSelect />, { wrapper: Wrapper });
+    render(<LanguageSelect />, { wrapper: withNuqsTestingAdapter() });
 
     expect(screen.getByText("Popular")).toBeInTheDocument();
     expect(screen.getByText("Other")).toBeInTheDocument();
@@ -138,7 +142,7 @@ describe("LanguageSelect", () => {
   it("renders popular languages list", () => {
     localStorage.setItem("language", JSON.stringify("All Languages"));
 
-    render(<LanguageSelect />, { wrapper: Wrapper });
+    render(<LanguageSelect />, { wrapper: withNuqsTestingAdapter() });
 
     expect(screen.getAllByText("TypeScript").length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText("JavaScript").length).toBeGreaterThanOrEqual(1);
@@ -148,7 +152,7 @@ describe("LanguageSelect", () => {
   it("renders other languages list", () => {
     localStorage.setItem("language", JSON.stringify("All Languages"));
 
-    render(<LanguageSelect />, { wrapper: Wrapper });
+    render(<LanguageSelect />, { wrapper: withNuqsTestingAdapter() });
 
     expect(screen.getAllByText("Java").length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText("Kotlin").length).toBeGreaterThanOrEqual(1);

--- a/apps/web/src/components/language-select.tsx
+++ b/apps/web/src/components/language-select.tsx
@@ -36,7 +36,7 @@ import { languages } from "@/lib/languages";
 
 function LanguageSelectContent({ onClose }: { onClose: () => void }) {
   const [languageLocalStorage, setLanguageLocalStorage] = useAtom(languageAtom);
-  const [language, setLanguage] = useQueryState(
+  const [, setLanguage] = useQueryState(
     "language",
     parseAsStringEnum(Object.keys(languages.colors)).withDefault(
       languageLocalStorage,

--- a/apps/web/src/components/language-select.tsx
+++ b/apps/web/src/components/language-select.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { useAtom } from "jotai";
+import { parseAsStringEnum, useQueryState } from "nuqs";
 import { useRef, useState } from "react";
-import { useLanguageValue, useSetLanguage } from "@/atoms/language";
+import { languageAtom, useLanguageValue } from "@/atoms/language";
 import { LanguageIndicator } from "@/components/language-indicator";
 import { Button } from "@/components/ui/button";
 import {
@@ -33,7 +35,13 @@ import { useMediaQuery } from "@/hooks/use-media-query";
 import { languages } from "@/lib/languages";
 
 function LanguageSelectContent({ onClose }: { onClose: () => void }) {
-  const setLanguage = useSetLanguage();
+  const [languageLocalStorage, setLanguageLocalStorage] = useAtom(languageAtom);
+  const [language, setLanguage] = useQueryState(
+    "language",
+    parseAsStringEnum(Object.keys(languages.colors)).withDefault(
+      languageLocalStorage,
+    ),
+  );
   return (
     <Command className="bg-transparent">
       <CommandInput placeholder="Search for a language" />
@@ -43,6 +51,7 @@ function LanguageSelectContent({ onClose }: { onClose: () => void }) {
           <CommandItem
             onSelect={() => {
               setLanguage("All Languages");
+              setLanguageLocalStorage("All Languages");
               onClose();
             }}
             value="all"
@@ -57,6 +66,7 @@ function LanguageSelectContent({ onClose }: { onClose: () => void }) {
               key={language}
               onSelect={() => {
                 setLanguage(language);
+                setLanguageLocalStorage(language);
                 onClose();
               }}
               value={language}
@@ -72,6 +82,7 @@ function LanguageSelectContent({ onClose }: { onClose: () => void }) {
               key={language}
               onSelect={() => {
                 setLanguage(language);
+                setLanguageLocalStorage(language);
                 onClose();
               }}
               value={language}

--- a/apps/web/src/components/language-select.tsx
+++ b/apps/web/src/components/language-select.tsx
@@ -34,12 +34,31 @@ import {
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { languages } from "@/lib/languages";
 
+const ALL_LANGUAGES_LABEL = "All Languages";
+const ALL_LANGUAGES_QUERY_VALUE = "all";
+const languageQueryValues = [
+  ALL_LANGUAGES_QUERY_VALUE,
+  ...Object.keys(languages.colors),
+];
+
+function getDefaultLanguageQueryValue(language: string) {
+  if (language === ALL_LANGUAGES_LABEL) {
+    return ALL_LANGUAGES_QUERY_VALUE;
+  }
+
+  if (languageQueryValues.includes(language)) {
+    return language;
+  }
+
+  return ALL_LANGUAGES_QUERY_VALUE;
+}
+
 function LanguageSelectContent({ onClose }: { onClose: () => void }) {
   const [languageLocalStorage, setLanguageLocalStorage] = useAtom(languageAtom);
   const [, setLanguage] = useQueryState(
     "language",
-    parseAsStringEnum(Object.keys(languages.colors)).withDefault(
-      languageLocalStorage,
+    parseAsStringEnum(languageQueryValues).withDefault(
+      getDefaultLanguageQueryValue(languageLocalStorage),
     ),
   );
   return (
@@ -50,14 +69,14 @@ function LanguageSelectContent({ onClose }: { onClose: () => void }) {
         <CommandGroup>
           <CommandItem
             onSelect={() => {
-              setLanguage("All Languages");
-              setLanguageLocalStorage("All Languages");
+              setLanguage(ALL_LANGUAGES_QUERY_VALUE);
+              setLanguageLocalStorage(ALL_LANGUAGES_LABEL);
               onClose();
             }}
-            value="all"
+            value={ALL_LANGUAGES_QUERY_VALUE}
           >
-            <LanguageIndicator language="All Languages" />
-            All Languages
+            <LanguageIndicator language={ALL_LANGUAGES_LABEL} />
+            {ALL_LANGUAGES_LABEL}
           </CommandItem>
         </CommandGroup>
         <CommandGroup heading="Popular">

--- a/apps/web/src/components/period-select.test.tsx
+++ b/apps/web/src/components/period-select.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { Provider } from "jotai";
+import { withNuqsTestingAdapter } from "nuqs/adapters/testing";
 import type { ComponentProps, ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { PeriodSelect } from "./period-select";
@@ -77,15 +77,13 @@ vi.mock("@/hooks/use-media-query", () => ({
   useMediaQuery: vi.fn(() => false),
 }));
 
-function Wrapper({ children }: { children: ReactNode }) {
-  return <Provider>{children}</Provider>;
-}
-
 describe("PeriodSelect", () => {
   it("renders with current period label in the button", () => {
     localStorage.setItem("period", JSON.stringify("daily"));
 
-    render(<PeriodSelect data-testid="period-select" />, { wrapper: Wrapper });
+    render(<PeriodSelect data-testid="period-select" />, {
+      wrapper: withNuqsTestingAdapter(),
+    });
 
     // Daily appears both in button and dropdown
     const dailyElements = screen.getAllByText("Daily");
@@ -97,7 +95,7 @@ describe("PeriodSelect", () => {
   it("renders all period options in dropdown", () => {
     localStorage.setItem("period", JSON.stringify("daily"));
 
-    render(<PeriodSelect />, { wrapper: Wrapper });
+    render(<PeriodSelect />, { wrapper: withNuqsTestingAdapter() });
 
     // All periods appear in the dropdown options
     expect(screen.getAllByText("Daily").length).toBeGreaterThanOrEqual(1);
@@ -109,7 +107,7 @@ describe("PeriodSelect", () => {
   it("renders with weekly period when selected", () => {
     localStorage.setItem("period", JSON.stringify("weekly"));
 
-    render(<PeriodSelect />, { wrapper: Wrapper });
+    render(<PeriodSelect />, { wrapper: withNuqsTestingAdapter() });
 
     const weeklyButtons = screen.getAllByText("Weekly");
     // At least one in the trigger button and one in the dropdown

--- a/apps/web/src/components/period-select.tsx
+++ b/apps/web/src/components/period-select.tsx
@@ -1,5 +1,7 @@
+import { useAtom } from "jotai";
+import { parseAsStringEnum, useQueryState } from "nuqs";
 import { useRef, useState } from "react";
-import { usePeriodValue, useSetPeriod } from "@/atoms/period";
+import { periodAtom, usePeriodValue, useSetPeriod } from "@/atoms/period";
 import { Button } from "@/components/ui/button";
 import {
   CalendarDaysIcon,
@@ -40,8 +42,13 @@ const periods = [
 ];
 
 function PeriodSelectContent({ onClose }: { onClose: () => void }) {
-  const period = usePeriodValue();
-  const setPeriod = useSetPeriod();
+  const [periodLocalStorage, setPeriodLocalStorage] = useAtom(periodAtom);
+  const [period, setPeriod] = useQueryState(
+    "period",
+    parseAsStringEnum(["daily", "weekly", "monthly", "yearly"]).withDefault(
+      periodLocalStorage,
+    ),
+  );
   return (
     <Command className="bg-transparent" value={period}>
       <CommandInput placeholder="Search for a period" />
@@ -53,6 +60,7 @@ function PeriodSelectContent({ onClose }: { onClose: () => void }) {
               key={p.value}
               onSelect={() => {
                 setPeriod(p.value);
+                setPeriodLocalStorage(p.value);
                 onClose();
               }}
               value={p.value}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -10,6 +10,7 @@ import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
 import type { TRPCOptionsProxy } from "@trpc/tanstack-react-query";
 import type { AppRouter } from "@twending/api/routers/index";
 import { Provider } from "jotai";
+import { NuqsAdapter } from "nuqs/adapters/tanstack-router";
 import posthog from "posthog-js";
 import { useEffect, useState } from "react";
 
@@ -131,7 +132,9 @@ function RootDocument() {
         </head>
         <body>
           <main className="grid h-svh grid-rows-[auto_1fr]">
-            <Outlet />
+            <NuqsAdapter>
+              <Outlet />
+            </NuqsAdapter>
           </main>
           <TanStackRouterDevtools position="bottom-left" />
           <ReactQueryDevtools buttonPosition="bottom-right" position="bottom" />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       nitro:
         specifier: 3.0.1-alpha.2
         version: 3.0.1-alpha.2(lru-cache@11.2.6)(rollup@4.60.2)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      nuqs:
+        specifier: ^2.8.9
+        version: 2.8.9(@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       posthog-js:
         specifier: ^1.369.3
         version: 1.369.3
@@ -1555,6 +1558,9 @@ packages:
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
+
+  '@standard-schema/spec@1.0.0':
+    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -3229,6 +3235,27 @@ packages:
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
+  nuqs@2.8.9:
+    resolution: {integrity: sha512-8ou6AEwsxMWSYo2qkfZtYFVzngwbKmg4c00HVxC1fF6CEJv3Fwm6eoZmfVPALB+vw8Udo7KL5uy96PFcYe1BIQ==}
+    peerDependencies:
+      '@remix-run/react': '>=2'
+      '@tanstack/react-router': ^1
+      next: '>=14.2.0'
+      react: '>=18.2.0 || ^19.0.0-0'
+      react-router: ^5 || ^6 || ^7
+      react-router-dom: ^5 || ^6 || ^7
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@tanstack/react-router':
+        optional: true
+      next:
+        optional: true
+      react-router:
+        optional: true
+      react-router-dom:
+        optional: true
 
   nypm@0.6.5:
     resolution: {integrity: sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==}
@@ -5323,6 +5350,8 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@standard-schema/spec@1.0.0': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@tailwindcss/node@4.2.2':
@@ -7001,6 +7030,13 @@ snapshots:
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
+
+  nuqs@2.8.9(@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5):
+    dependencies:
+      '@standard-schema/spec': 1.0.0
+      react: 19.2.5
+    optionalDependencies:
+      '@tanstack/react-router': 1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
 
   nypm@0.6.5:
     dependencies:


### PR DESCRIPTION
- Updated LanguageSelect and PeriodSelect components to use nuqs for state management.
- Replaced local wrapper with nuqs testing adapter in corresponding tests.
- Added nuqs as a dependency in package.json and updated pnpm-lock.yaml accordingly.
- Enhanced language and period selection handling with local storage integration.